### PR TITLE
Updated DCO to current Linux Foundation address

### DIFF
--- a/DCO
+++ b/DCO
@@ -2,8 +2,8 @@ Developer Certificate of Origin
 Version 1.1
 
 Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-660 York Street, Suite 102,
-San Francisco, CA 94110 USA
+1796 18th St, 
+San Francisco, CA 94107
 
 Everyone is permitted to copy and distribute verbatim copies of this
 license document, but changing it is not allowed.


### PR DESCRIPTION
Updated DCO to current Linux Foundation address. Worth noting that the DCO copyright will expire in 2026 without change
